### PR TITLE
Lensy API

### DIFF
--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -13,14 +13,14 @@ import Test.QuickCheck
 
 import Control.Applicative
 
-genTemplate :: Gen T.Template
+genTemplate :: Gen (T.Template T.Name)
 genTemplate = oneof [ do t <- genText
                          return (T.lit t)
                     , do t1 <- genText
-                         t2 <- genText
+                         t2 <- fmap T.Name genText
                          t3 <- genTemplate
                          return (T.lit t1 <> T.placeholder t2 <> t3)
-                    , do t1 <- genText
+                    , do t1 <- fmap T.Name genText
                          t2 <- genTemplate
                          return (T.placeholder t1 <> t2)
                     ]
@@ -36,14 +36,14 @@ main = do
   -- Parser and pretty printer are compatible
   quickCheck $ do
     t <- genTemplate
-    return $ T.parseTemplate (T.printTemplate t) == t
+    return $ T.parseTemplate (T.renderTemplate t) == t
   quickCheck $ do
     s <- genTemplateString
-    return $ T.printTemplate (T.parseTemplate s) == s
+    return $ T.renderTemplate (T.parseTemplate s) == s
 
-  -- printTemplate is a Monoid morphism
-  quickCheck $ T.printTemplate mempty == mempty
+  -- renderTemplate is a Monoid morphism
+  quickCheck $ T.renderTemplate mempty == mempty
   quickCheck $ do
     t1 <- genTemplate
     t2 <- genTemplate
-    return $ T.printTemplate (t1 <> t2) == T.printTemplate t1 <> T.printTemplate t2
+    return $ T.renderTemplate (t1 <> t2) == T.renderTemplate t1 <> T.renderTemplate t2


### PR DESCRIPTION
- Makes `Template` into a `Functor` and `Monad` for full and partial replacement of template placeholders.
- The `placeholders` traversal replaces `applyTemplate`, and is more general.
